### PR TITLE
Allow mermaid rendering locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
 
             cd pynb-dag-runner/tools/draw-runlog-visuals
             make draw-runlog-visuals IMG_OUTPUT_FORMAT="png"
-            make draw-runlog-visuals IMG_OUTPUT_FORMAT="svg"
+
+            # TODO: Generated task-dependencies svg is broken
+            # make draw-runlog-visuals IMG_OUTPUT_FORMAT="svg"
 
       # -- store pipeline outputs --
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,11 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
             export RUNLOGS_ROOT="$(pwd)/pipeline-outputs/runlogs"
-            export PNG_OUTPUT_DIRECTORY="$(pwd)/pipeline-outputs"
+            export IMG_OUTPUT_DIRECTORY="$(pwd)/pipeline-outputs"
 
             cd pynb-dag-runner/tools/draw-runlog-visuals
-            make draw-runlog-visuals \
-                RUNLOGS_ROOT="$RUNLOGS_ROOT" \
-                PNG_OUTPUT_DIRECTORY="$PNG_OUTPUT_DIRECTORY"
+            make draw-runlog-visuals IMG_OUTPUT_FORMAT="png"
+            make draw-runlog-visuals IMG_OUTPUT_FORMAT="svg"
 
       # -- store pipeline outputs --
 

--- a/makefile
+++ b/makefile
@@ -67,16 +67,32 @@ clean:
 	        (cd common; make clean; ) && \
 	        (cd mnist-demo-pipeline; make clean-pipeline-outputs)"
 
+draw-runlog-visuals:
+	# Rendering images should only be run when RUN_ENVIRONMENT="ci"
+	# (rending will not work in dev setup due to different directory layout)
+	#
+	# Only rendering png for now, generated svg seem broken(?)
+	if [ "$(RUN_ENVIRONMENT)" = "ci" ]; then ( \
+	    export RUNLOGS_ROOT="$$(pwd)/pipeline-outputs/runlogs"; \
+	    export IMG_OUTPUT_DIRECTORY="$$(pwd)/pipeline-outputs"; \
+	    cd pynb-dag-runner/tools/draw-runlog-visuals; \
+	    make draw-runlog-visuals IMG_OUTPUT_FORMAT="png"; \
+	); fi
+
 test-and-run-pipeline:
 	# Single command to run all tests and the demo pipeline
+	make clean
+
 	make docker-run-in-cicd \
 	    RUN_ENVIRONMENT=$(RUN_ENVIRONMENT) \
 	    COMMAND="( \
 	        cd common; \
 	        make install; \
 	        make clean; \
-	        ) && ( \
+	    ) && ( \
 	        cd mnist-demo-pipeline; \
 	        make test-mypy test-black; \
 	        make run; \
 	    )"
+
+	make draw-runlog-visuals RUN_ENVIRONMENT=$(RUN_ENVIRONMENT)

--- a/makefile
+++ b/makefile
@@ -69,9 +69,10 @@ clean:
 
 draw-runlog-visuals:
 	# Rendering images should only be run when RUN_ENVIRONMENT="ci"
-	# (rending will not work in dev setup due to different directory layout)
+	# (rending will not work in RUN_ENVIRONMENT="ci" due to different
+	# directory layout)
 	#
-	# Only rendering png for now, generated svg seem broken(?)
+	# Only rendering png for now, generated task-dependencies.svg is broken
 	if [ "$(RUN_ENVIRONMENT)" = "ci" ]; then ( \
 	    export RUNLOGS_ROOT="$$(pwd)/pipeline-outputs/runlogs"; \
 	    export IMG_OUTPUT_DIRECTORY="$$(pwd)/pipeline-outputs"; \


### PR DESCRIPTION
This PR also makes it possible to render svg files.

This is disabled, since output task-dependencies.svg is broken (at least with Firefox).