### PR TITLE
Update (broken) dependencies; add common tests to makefile

### DIFF
--- a/docker/requirements.ci.txt
+++ b/docker/requirements.ci.txt
@@ -7,13 +7,13 @@
 #  - https://docs.microsoft.com/en-us/azure/azure-sql-edge/deploy-onnx
 protobuf==3.16.0
 onnx==1.10.1
-skl2onnx==1.9.3
-onnxruntime==1.9.0
+skl2onnx==1.11.2
+onnxruntime==1.12.0
 
 #
-scikit-learn==0.23.2
-pandas==1.3.5
-matplotlib==3.5.1
+scikit-learn==1.1.1
+pandas==1.4.3
+matplotlib==3.5.2
 
 # libraries for running unit and static tests on code
 pytest==6.2.5

--- a/makefile
+++ b/makefile
@@ -83,6 +83,7 @@ test-and-run-pipeline:
 	    COMMAND="( \
 	        cd common; \
 	        make install; \
+	        make test-pytest test-mypy test-black; \
 	        make clean; \
 	    ) && ( \
 	        cd mnist-demo-pipeline; \


### PR DESCRIPTION
### Error message

```
../../.local/lib/python3.8/site-packages/sklearn/cross_decomposition/__init__.py:1: in <module>
    from ._pls import PLSCanonical, PLSRegression, PLSSVD
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    """
    The :mod:`sklearn.pls` module implements Partial Least Squares (PLS).
    """
    
    # Author: Edouard Duchesnay <edouard.duchesnay@cea.fr>
    # License: BSD 3 clause
    
    import warnings
    from abc import ABCMeta, abstractmethod
    
    import numpy as np
>   from scipy.linalg import pinv2, svd
E   ImportError: cannot import name 'pinv2' from 'scipy.linalg' (/home/host_user/.local/lib/python3.8/site-packages/scipy/linalg/__init__.py)
```
### Cause

From scipy 1.9 release notes "Removed linalg.pinv2."
- https://docs.scipy.org/doc/scipy/release.1.9.0.html


### Example broken runs:

- https://github.com/matiasdahl/dev-mnist-digits-demo-pipeline/runs/7591052112?check_suite_focus=true
- https://github.com/pynb-dag-runner/mnist-digits-demo-pipeline/runs/7589803739?check_suite_focus=true

---

Updating dependencies to latest versions seem to fix the bug