### PR TITLE
Install pynb-dag-runner via pip install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pynb-dag-runner"]
-	path = pynb-dag-runner
-	url = git@github.com:pynb-dag-runner/pynb-dag-runner.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pynb-dag-runner"]
+	path = pynb-dag-runner
+	url = https://github.com/pynb-dag-runner/pynb-dag-runner.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pynb-dag-runner"]
 	path = pynb-dag-runner
-	url = https://github.com/pynb-dag-runner/pynb-dag-runner.git
+	url = git@github.com:pynb-dag-runner/pynb-dag-runner.git

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -6,11 +6,6 @@ FROM mnist-demo-pipeline-base
 COPY docker/requirements.ci.txt /home/host_user/
 RUN pip3 install --user -r /home/host_user/requirements.ci.txt
 
-# Install pynb-dag-runner library
-COPY pynb-dag-runner/workspace/pynb_dag_runner/dist/pynb_dag_runner-*-py3-none-any.whl \
-     /home/host_user/
-RUN pip3 install --user /home/host_user/pynb_dag_runner-*-py3-none-any.whl
-
 ENV MYPY_CACHE_DIR=/home/host_user/.cache/mypy
 RUN mkdir -p $MYPY_CACHE_DIR
 

--- a/docker/requirements.ci.txt
+++ b/docker/requirements.ci.txt
@@ -19,3 +19,6 @@ matplotlib==3.5.2
 pytest==6.2.5
 black==22.3.0
 mypy==0.931
+
+#
+pynb-dag-runner==0.0.6

--- a/makefile
+++ b/makefile
@@ -4,11 +4,7 @@ SHELL := /bin/bash
 RUN_ENVIRONMENT ?= "dev"
 
 docker-build-all:
-	# For now manually build wheel file for pynb-dag-runner library dependency
-	(cd pynb-dag-runner; \
-	    make clean; make docker-build-all; make build)
-
-	# Build docker images for mnist-demo-pipeline
+	# Build docker images for running mnist-demo-pipeline
 	(cd docker; make \
 	    build-base-env-docker-image \
 	    build-cicd-env-docker-image \


### PR DESCRIPTION
Install pynb-dag-runner Python dependency using pip install

The git-submodule is not yet removed since it contains some scripts for Mermaid -> png conversion. These should be revised after Mermaid rendering is done in UI  