### PR TITLE
Refactor `write-summary` to only depend on OTel Spans JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,33 @@ jobs:
               GITHUB_REF_NAME
               GITHUB_EVENT_NAME
 
-      # -- store pipeline outputs --
+      # -- store OpenTelemetry pipeline output log --
 
-      - name: "Expand OpenTelemetry file into directory structure; Create Mermaid diagrams"
+      - name: "Store pipeline run OpenTelemetry logs"
+        uses: actions/upload-artifact@v2
+        with:
+          name: pipeline-opentelemetry-spans
+          path: |
+              ${{ github.workspace }}/pipeline-outputs/opentelemetry-spans.json
+          if-no-files-found: error
+          retention-days: 20
+
+      - name: "Create custom (Markdown) pipeline summary to show in Github actions page"
+        run: |
+            # https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/
+            make in-cicd-docker/run-command \
+                COMMAND="(\
+                    cd mnist-demo-pipeline; \
+                    make create-pipeline-run-summary \
+                        OTEL_SPANS_OUTPUTFILE=/pipeline-outputs/opentelemetry-spans.json \
+                        OUTPUT_MARKDOWN_FILE=/pipeline-outputs/pipeline_run_summary.md
+                )"
+
+            cat ${{ github.workspace }}/pipeline-outputs/pipeline_run_summary.md > $GITHUB_STEP_SUMMARY
+
+      # --- Expand OpenTelemetry JSON into a directory structure, and store as build artifact --
+
+      - name: "Expand OpenTelemetry JSON log file into a directory structure for easier inspection"
         run: |
             make in-cicd-docker/run-command \
                 COMMAND="( \
@@ -127,19 +151,7 @@ jobs:
                     make expand-opentelemetry-spans-into-directory-structure; \
                 )"
 
-      - name: "Report pipeline summary to to Github actions page"
-        run: |
-            # https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/
-            make in-cicd-docker/run-command \
-                COMMAND="(\
-                    cd mnist-demo-pipeline; \
-                    make add-run-summary \
-                        PIPELINE_OUTPUTS_PATH=/pipeline-outputs/ \
-                )"
-
-            cat ${{ github.workspace }}/pipeline-outputs/pipeline_run_summary.md > $GITHUB_STEP_SUMMARY
-
-      # Upload action uses a separate token (and not GITHUB_TOKEN), see
+      # The Github upload-artifact-action uses a separate token (and not GITHUB_TOKEN), see
       # https://github.com/actions/upload-artifact/issues/197
       - name: "Store pipeline output files"
         uses: actions/upload-artifact@v2
@@ -150,13 +162,4 @@ jobs:
               !**/.gitkeep
               !opentelemetry-spans.json
           if-no-files-found: error
-          retention-days: 20
-
-      - name: "Store pipeline run OpenTelemetry logs"
-        uses: actions/upload-artifact@v2
-        with:
-          name: pipeline-opentelemetry-spans
-          path: |
-              ${{ github.workspace }}/pipeline-outputs/opentelemetry-spans.json
-          if-no-files-found: error
-          retention-days: 20
+          retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
                     cd mnist-demo-pipeline; \
                     make create-pipeline-run-summary \
                         OTEL_SPANS_OUTPUTFILE=/pipeline-outputs/opentelemetry-spans.json \
-                        OUTPUT_MARKDOWN_FILE=/pipeline-outputs/pipeline_run_summary.md
+                        OUTPUT_MARKDOWN_FILE=/pipeline-outputs/pipeline_run_summary.md \
                 )"
 
             cat ${{ github.workspace }}/pipeline-outputs/pipeline_run_summary.md > $GITHUB_STEP_SUMMARY

--- a/workspace/common/common/io.py
+++ b/workspace/common/common/io.py
@@ -21,7 +21,7 @@ def write_numpy(path: Path, numpy_obj):
     """
     Serialize and write a numpy array to a local file
     """
-    if path.suffix == ".numpy":
+    if path.suffix != ".numpy":
         raise ValueError(f"Path {path} should have .numpy suffix!")
 
     # Create local directory for file if it does not exist
@@ -36,7 +36,7 @@ def read_numpy(path: Path):
     Read numpy array from a local file saved with write_numpy, see above
     """
 
-    if path.suffix == ".numpy":
+    if path.suffix != ".numpy":
         raise ValueError(f"Path {path} should have .numpy suffix!")
 
     if not path.is_file():

--- a/workspace/common/common/io.py
+++ b/workspace/common/common/io.py
@@ -21,7 +21,8 @@ def write_numpy(path: Path, numpy_obj):
     """
     Serialize and write a numpy array to a local file
     """
-    assert path.suffix == ".numpy"
+    if path.suffix == ".numpy":
+        raise ValueError(f"Path {path} should have .numpy suffix!")
 
     # Create local directory for file if it does not exist
     os.makedirs(path.parent, exist_ok=True)
@@ -34,8 +35,12 @@ def read_numpy(path: Path):
     """
     Read numpy array from a local file saved with write_numpy, see above
     """
-    assert path.suffix == ".numpy"
-    assert path.is_file()
+
+    if path.suffix == ".numpy":
+        raise ValueError(f"Path {path} should have .numpy suffix!")
+
+    if not path.is_file():
+        raise ValueError(f"Path {path} does not exist!")
 
     with open(path, "rb") as f:
         return np.load(f)
@@ -51,7 +56,8 @@ def write_onnx(path: Path, model_onnx: onnx.onnx_ml_pb2.ModelProto):
 
 
 def read_onnx(path: Path) -> InferenceSession:
-    assert path.is_file()
+    if not path.is_file():
+        raise ValueError(f"Path {path} does not exist!")
 
     rt.set_seed(0)
     return rt.InferenceSession(path.read_bytes())

--- a/workspace/mnist-demo-pipeline/makefile
+++ b/workspace/mnist-demo-pipeline/makefile
@@ -12,13 +12,14 @@ run-pipeline:
 	        --run_environment ${RUN_ENVIRONMENT} \
 	)
 
-add-run-summary:
-	@echo "*** Create summary of pipeline run ... ***"
+create-pipeline-run-summary:
+	@echo "*** Create pipeline run summary from OpenTelemetry JSON file ... ***"
 	( \
 	    cd mnist-demo-pipeline; \
 	    python3 -u \
 	        reporting.py \
-	        --pipeline_outputs_path ${PIPELINE_OUTPUTS_PATH} \
+	        --input_otel_spans_json_file ${OTEL_SPANS_OUTPUTFILE} \
+	        --output_markdown_file ${OUTPUT_MARKDOWN_FILE} \
 	)
 
 expand-opentelemetry-spans-into-directory-structure:
@@ -30,13 +31,16 @@ expand-opentelemetry-spans-into-directory-structure:
 	    --output_filepath_mermaid_dag   /pipeline-outputs/dag.mmd
 	@echo "- done"
 
+
+# ---
+
 local-dev-run-pipeline:
-	@# TODO: move steps into driver where it makes sense (it has all parameters)
 	$(MAKE) run-pipeline RUN_ENVIRONMENT=dev
 
-	# Skip summary for local-dev, since this step depends on environment variables only
-	# set in Github
-	# $(MAKE) add-run-summary PIPELINE_OUTPUTS_PATH=/pipeline-outputs/
+	$(MAKE) create-pipeline-run-summary \
+	    OTEL_SPANS_OUTPUTFILE=/pipeline-outputs/opentelemetry-spans.json \
+	    OUTPUT_MARKDOWN_FILE=/pipeline-outputs/summary.md
+
 	$(MAKE) expand-opentelemetry-spans-into-directory-structure
 
 test-mypy:

--- a/workspace/mnist-demo-pipeline/mnist-demo-pipeline/reporting.py
+++ b/workspace/mnist-demo-pipeline/mnist-demo-pipeline/reporting.py
@@ -1,30 +1,64 @@
+from typing import Optional
+
+#
 import json
 from pathlib import Path
-from functools import lru_cache
+
+#
+from pynb_dag_runner.opentelemetry_helpers import Spans
+from pynb_dag_runner.opentelemetry_task_span_parser import get_pipeline_iterators
+
+from otel_output_parser.mermaid_graphs import (
+    make_mermaid_dag_inputfile,
+    make_mermaid_gantt_inputfile,
+)
 
 
-@lru_cache
 def args():
     from argparse import ArgumentParser
 
     parser = ArgumentParser()
     parser.add_argument(
-        "--pipeline_outputs_path",
+        "--input_otel_spans_json_file",
         type=Path,
-        help="output path where OpenTelemetry spans have been expanded (tmp)",
+        help="input filepath with logged spans (as an OpenTelemetry JSON file) for pipeline run",
+    )
+    parser.add_argument(
+        "--output_markdown_file",
+        type=Path,
+        help="filepath where to write output markdown report",
     )
 
     return parser.parse_args()
 
 
-print(f"--- Command line parameters")
-print(f"  - pipeline_outputs_path         : {args().pipeline_outputs_path}")
+def load_spans() -> Spans:
+    return Spans(json.loads(args().input_otel_spans_json_file.read_text()))
 
 
-def get_url_to_this_run(pipeline_outputs_path: Path) -> str:
-    pipeline_attributes = json.loads(
-        (pipeline_outputs_path / "pipeline-outputs" / "pipeline.json").read_text()
-    )["attributes"]
+def get_pipeline_attributes(spans: Spans):
+    pipeline_metadata, _ = get_pipeline_iterators(spans)
+    return pipeline_metadata["attributes"]
+
+
+def is_remote_run(spans: Spans) -> bool:
+    """
+    Is the logged spans from a run a Github CI/CD pipeline?
+    """
+    return {
+        "pipeline.github.repository",
+        "pipeline.pipeline_run_id",
+    } <= get_pipeline_attributes(spans).keys()
+
+
+print(f"  - input_otel_spans_json_file  : {args().input_otel_spans_json_file}")
+print(f"  - output_markdown_file        : {args().output_markdown_file}")
+
+
+def get_url_to_this_run(spans: Spans) -> Optional[str]:
+    assert is_remote_run(spans)
+
+    pipeline_attributes = get_pipeline_attributes(spans)
 
     repo_owner, repo_name = pipeline_attributes["pipeline.github.repository"].split("/")
     run_id = pipeline_attributes["pipeline.pipeline_run_id"]
@@ -32,39 +66,49 @@ def get_url_to_this_run(pipeline_outputs_path: Path) -> str:
     return f"https://{repo_owner}.github.io/{repo_name}/#/experiments/all-pipelines-runs/runs/{run_id}"
 
 
-def make_markdown_report(pipeline_outputs_path: Path) -> str:
+def make_markdown_report(spans: Spans) -> str:
+    remote_run: bool = is_remote_run(spans)
     report_lines = []
 
-    runlink = get_url_to_this_run(pipeline_outputs_path)
-    report_lines.append(
-        f"Inspect details on this pipeline run: [Github Pages link]({runlink})"
-    )
-    report_lines.append("")
+    #
+    if remote_run:
+        runlink = get_url_to_this_run(spans)
+        report_lines.append(
+            f"Inspect details on this pipeline run: [Github Pages link]({runlink})"
+        )
+        report_lines.append("")
 
+    # Add DAG diagram
     report_lines.append("## DAG diagram of task dependencies in this pipeline")
     report_lines.append("```mermaid")
-    report_lines.append((pipeline_outputs_path / "dag.mmd").read_text())
+    report_lines.append(make_mermaid_dag_inputfile(spans, generate_links=remote_run))
     report_lines.append("```")
-    report_lines.append("Click on a task for more details.")
 
+    if remote_run:
+        report_lines.append("Click on a task for more details.")
+
+    # Add Gantt diagram
     report_lines.append("## Gantt diagram of task runs in pipeline")
     report_lines.append("```mermaid")
-    report_lines.append((pipeline_outputs_path / "gantt.mmd").read_text())
+    report_lines.append(make_mermaid_gantt_inputfile(spans))
     report_lines.append("```")
     report_lines.append("---")
-    report_lines.append(
-        "Note: the above links point to a static Github Pages site built using build artifacts "
-        "for this repo. The links will only work (1) after the static site has been built, and "
-        "(2) if the build artifacts existed when the site was last built. "
-        "Since Github Build artifacts has maximum retention period of 90 days, the "
-        "links will not work forever."
-    )
+
+    if remote_run:
+        report_lines.append(
+            "Note: the above links point to a static Github Pages site built using "
+            "build artifacts for this repo. The links will only work "
+            "(1) after the static site has been built, and "
+            "(2) if the build artifacts existed when the site was last built. "
+            "Since Github Build artifacts has maximum retention period of 90 days, "
+            "the links will not work forever."
+        )
 
     return "\n".join(report_lines)
 
 
-(args().pipeline_outputs_path / "pipeline_run_summary.md").write_text(
-    make_markdown_report(args().pipeline_outputs_path)
+args().output_markdown_file.write_text(
+    make_markdown_report(load_spans()),
 )
 
 


### PR DESCRIPTION
No longer use data from expanded directory structure